### PR TITLE
Autodetection issue of languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.2.1
+
+  * [Issue #4](https://github.com/mackoj/language-gherkin-i18n/issues/4): Update gnerateGlobalConfig.php to autodetect language in CRLF and LF line ending files 
+  * Update Grammar and Settings from last  [i18n.json](https://github.com/cucumber/gherkin/blob/master/lib/gherkin/i18n.json) update
+  * Minor Readme / Changelog / package.json modification
+
+
 # 1.2.0
 
   * Update Grammar and Settings from last  [i18n.json](https://github.com/cucumber/gherkin/blob/master/lib/gherkin/i18n.json) update

--- a/README.md
+++ b/README.md
@@ -6,15 +6,15 @@ This `Gherkin language in Atom` plugin offers:
   * Internationalization in 64 languages based on [i18n.json](https://github.com/cucumber/gherkin/blob/master/lib/gherkin/i18n.json)
   * Simple Completion in 64 languages
 
-The matching is done by looking at the very first line of each of you `.feature` files.
+The languages matching is done by looking at the very first line of each of the `.feature` files.
 
-So to use a specific language, set the first line of your feature file with the pattern `# language: <langID>`, e.g. `# language: fr`.
+In order to use a specific language, set the first line of your feature file with the following pattern:  `# language: <langID>`, e.g. `# language: fr`.
 
 When `# language: <langID>` is not specified, it defaults to English.
 
 The source documentation is the [Cucumber documentation for spoken languages](https://github.com/cucumber/cucumber/wiki/Spoken-languages)
 
-Syntax color best match with Atom One Dark theme.
+Syntax color works better with Atom One Dark theme.
 
 ![English / French / German / Japanese / Hebrew](https://github.com/mackoj/language-gherkin-i18n/blob/develop/preview.gif)
 
@@ -23,7 +23,7 @@ Syntax color best match with Atom One Dark theme.
   * Gherkin (2.12.2)
   * Cucumber (1.39.19 -> 2.0.0.rc.5)
 
-# List of language actually supported
+# List of supported languages
 
 |Language Name(English)|Language Name(Native)|langID|
 |----------------------|---------------------|------|
@@ -95,7 +95,7 @@ Syntax color best match with Atom One Dark theme.
 # Contributing
 
 Contributions are greatly appreciated.
-If you find a bug please consider create a issue for it to be treated for it to be treated fast consider add a test case in the spec file in order to reproduce it.
+If you find a bug please consider creating an issue for it. To be treated fast consider adding a test case in the spec file in order to reproduce it.
 Please fork this repository and open a pull request to add snippets, make grammar tweaks, etc.
 
 # How it is made
@@ -104,8 +104,9 @@ Using a template for the grammar and another one for the autocompletion, we pars
 
 # ToDo
 
-  * Add unit test
+  * Add unit tests
   * Add Snippets for table and most used keyword (feature, scenario, etc...)
   * Improve parser
   * Improve documentation
-  * Automate `language-gherkin-i18n` update by watching `i18n.json` update in released version
+  * Automate `language-gherkin-i18n` update by watching `i18n.json` update in its released version
+  * Redo all the scrips in a more cleaner way and with Javascript

--- a/generators/generateGlobalConfig.php
+++ b/generators/generateGlobalConfig.php
@@ -20,7 +20,7 @@ $smallLangWithADot = "__SMALLLANG_DOT__";
 $templateFolder = "/template";
 
 // Grammar
-$firstLineMatchLine = "'firstLineMatch' : '^# language: __LANG__$'";
+$firstLineMatchLine = "'firstLineMatch' : '^# language: __LANG__$(\\r)?\\n'";
 
 $grammarTemplateKeys = [
 	"__FEATURE__" => [ "name" => "feature", "separator" => "\\\\:|" ],

--- a/grammars/gherkin_af.cson
+++ b/grammars/gherkin_af.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.af'
 'name': 'Gherkin-af'
-'firstLineMatch' : '^# language: af$'
+'firstLineMatch' : '^# language: af$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_am.cson
+++ b/grammars/gherkin_am.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.am'
 'name': 'Gherkin-am'
-'firstLineMatch' : '^# language: am$'
+'firstLineMatch' : '^# language: am$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_ar.cson
+++ b/grammars/gherkin_ar.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.ar'
 'name': 'Gherkin-ar'
-'firstLineMatch' : '^# language: ar$'
+'firstLineMatch' : '^# language: ar$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_bg.cson
+++ b/grammars/gherkin_bg.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.bg'
 'name': 'Gherkin-bg'
-'firstLineMatch' : '^# language: bg$'
+'firstLineMatch' : '^# language: bg$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_bm.cson
+++ b/grammars/gherkin_bm.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.bm'
 'name': 'Gherkin-bm'
-'firstLineMatch' : '^# language: bm$'
+'firstLineMatch' : '^# language: bm$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_ca.cson
+++ b/grammars/gherkin_ca.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.ca'
 'name': 'Gherkin-ca'
-'firstLineMatch' : '^# language: ca$'
+'firstLineMatch' : '^# language: ca$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_cs.cson
+++ b/grammars/gherkin_cs.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.cs'
 'name': 'Gherkin-cs'
-'firstLineMatch' : '^# language: cs$'
+'firstLineMatch' : '^# language: cs$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_cy-GB.cson
+++ b/grammars/gherkin_cy-GB.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.cy-GB'
 'name': 'Gherkin-cy-GB'
-'firstLineMatch' : '^# language: cy-GB$'
+'firstLineMatch' : '^# language: cy-GB$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_da.cson
+++ b/grammars/gherkin_da.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.da'
 'name': 'Gherkin-da'
-'firstLineMatch' : '^# language: da$'
+'firstLineMatch' : '^# language: da$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_de.cson
+++ b/grammars/gherkin_de.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.de'
 'name': 'Gherkin-de'
-'firstLineMatch' : '^# language: de$'
+'firstLineMatch' : '^# language: de$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_el.cson
+++ b/grammars/gherkin_el.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.el'
 'name': 'Gherkin-el'
-'firstLineMatch' : '^# language: el$'
+'firstLineMatch' : '^# language: el$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_en-Scouse.cson
+++ b/grammars/gherkin_en-Scouse.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.en-Scouse'
 'name': 'Gherkin-en-Scouse'
-'firstLineMatch' : '^# language: en-Scouse$'
+'firstLineMatch' : '^# language: en-Scouse$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_en-au.cson
+++ b/grammars/gherkin_en-au.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.en-au'
 'name': 'Gherkin-en-au'
-'firstLineMatch' : '^# language: en-au$'
+'firstLineMatch' : '^# language: en-au$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_en-lol.cson
+++ b/grammars/gherkin_en-lol.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.en-lol'
 'name': 'Gherkin-en-lol'
-'firstLineMatch' : '^# language: en-lol$'
+'firstLineMatch' : '^# language: en-lol$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_en-old.cson
+++ b/grammars/gherkin_en-old.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.en-old'
 'name': 'Gherkin-en-old'
-'firstLineMatch' : '^# language: en-old$'
+'firstLineMatch' : '^# language: en-old$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_en-pirate.cson
+++ b/grammars/gherkin_en-pirate.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.en-pirate'
 'name': 'Gherkin-en-pirate'
-'firstLineMatch' : '^# language: en-pirate$'
+'firstLineMatch' : '^# language: en-pirate$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_en.cson
+++ b/grammars/gherkin_en.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.en'
 'name': 'Gherkin-en'
-'firstLineMatch' : '^# language: en$'
+'firstLineMatch' : '^# language: en$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_eo.cson
+++ b/grammars/gherkin_eo.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.eo'
 'name': 'Gherkin-eo'
-'firstLineMatch' : '^# language: eo$'
+'firstLineMatch' : '^# language: eo$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_es.cson
+++ b/grammars/gherkin_es.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.es'
 'name': 'Gherkin-es'
-'firstLineMatch' : '^# language: es$'
+'firstLineMatch' : '^# language: es$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_et.cson
+++ b/grammars/gherkin_et.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.et'
 'name': 'Gherkin-et'
-'firstLineMatch' : '^# language: et$'
+'firstLineMatch' : '^# language: et$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_fa.cson
+++ b/grammars/gherkin_fa.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.fa'
 'name': 'Gherkin-fa'
-'firstLineMatch' : '^# language: fa$'
+'firstLineMatch' : '^# language: fa$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_fi.cson
+++ b/grammars/gherkin_fi.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.fi'
 'name': 'Gherkin-fi'
-'firstLineMatch' : '^# language: fi$'
+'firstLineMatch' : '^# language: fi$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_fr.cson
+++ b/grammars/gherkin_fr.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.fr'
 'name': 'Gherkin-fr'
-'firstLineMatch' : '^# language: fr$'
+'firstLineMatch' : '^# language: fr$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_gj.cson
+++ b/grammars/gherkin_gj.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.gj'
 'name': 'Gherkin-gj'
-'firstLineMatch' : '^# language: gj$'
+'firstLineMatch' : '^# language: gj$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_gl.cson
+++ b/grammars/gherkin_gl.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.gl'
 'name': 'Gherkin-gl'
-'firstLineMatch' : '^# language: gl$'
+'firstLineMatch' : '^# language: gl$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_he.cson
+++ b/grammars/gherkin_he.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.he'
 'name': 'Gherkin-he'
-'firstLineMatch' : '^# language: he$'
+'firstLineMatch' : '^# language: he$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_hi.cson
+++ b/grammars/gherkin_hi.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.hi'
 'name': 'Gherkin-hi'
-'firstLineMatch' : '^# language: hi$'
+'firstLineMatch' : '^# language: hi$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_hr.cson
+++ b/grammars/gherkin_hr.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.hr'
 'name': 'Gherkin-hr'
-'firstLineMatch' : '^# language: hr$'
+'firstLineMatch' : '^# language: hr$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_ht.cson
+++ b/grammars/gherkin_ht.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.ht'
 'name': 'Gherkin-ht'
-'firstLineMatch' : '^# language: ht$'
+'firstLineMatch' : '^# language: ht$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_hu.cson
+++ b/grammars/gherkin_hu.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.hu'
 'name': 'Gherkin-hu'
-'firstLineMatch' : '^# language: hu$'
+'firstLineMatch' : '^# language: hu$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_id.cson
+++ b/grammars/gherkin_id.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.id'
 'name': 'Gherkin-id'
-'firstLineMatch' : '^# language: id$'
+'firstLineMatch' : '^# language: id$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_is.cson
+++ b/grammars/gherkin_is.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.is'
 'name': 'Gherkin-is'
-'firstLineMatch' : '^# language: is$'
+'firstLineMatch' : '^# language: is$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_it.cson
+++ b/grammars/gherkin_it.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.it'
 'name': 'Gherkin-it'
-'firstLineMatch' : '^# language: it$'
+'firstLineMatch' : '^# language: it$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_ja.cson
+++ b/grammars/gherkin_ja.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.ja'
 'name': 'Gherkin-ja'
-'firstLineMatch' : '^# language: ja$'
+'firstLineMatch' : '^# language: ja$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_jv.cson
+++ b/grammars/gherkin_jv.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.jv'
 'name': 'Gherkin-jv'
-'firstLineMatch' : '^# language: jv$'
+'firstLineMatch' : '^# language: jv$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_kn.cson
+++ b/grammars/gherkin_kn.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.kn'
 'name': 'Gherkin-kn'
-'firstLineMatch' : '^# language: kn$'
+'firstLineMatch' : '^# language: kn$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_ko.cson
+++ b/grammars/gherkin_ko.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.ko'
 'name': 'Gherkin-ko'
-'firstLineMatch' : '^# language: ko$'
+'firstLineMatch' : '^# language: ko$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_lt.cson
+++ b/grammars/gherkin_lt.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.lt'
 'name': 'Gherkin-lt'
-'firstLineMatch' : '^# language: lt$'
+'firstLineMatch' : '^# language: lt$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_lu.cson
+++ b/grammars/gherkin_lu.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.lu'
 'name': 'Gherkin-lu'
-'firstLineMatch' : '^# language: lu$'
+'firstLineMatch' : '^# language: lu$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_lv.cson
+++ b/grammars/gherkin_lv.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.lv'
 'name': 'Gherkin-lv'
-'firstLineMatch' : '^# language: lv$'
+'firstLineMatch' : '^# language: lv$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_nl.cson
+++ b/grammars/gherkin_nl.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.nl'
 'name': 'Gherkin-nl'
-'firstLineMatch' : '^# language: nl$'
+'firstLineMatch' : '^# language: nl$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_no.cson
+++ b/grammars/gherkin_no.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.no'
 'name': 'Gherkin-no'
-'firstLineMatch' : '^# language: no$'
+'firstLineMatch' : '^# language: no$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_pa.cson
+++ b/grammars/gherkin_pa.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.pa'
 'name': 'Gherkin-pa'
-'firstLineMatch' : '^# language: pa$'
+'firstLineMatch' : '^# language: pa$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_pl.cson
+++ b/grammars/gherkin_pl.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.pl'
 'name': 'Gherkin-pl'
-'firstLineMatch' : '^# language: pl$'
+'firstLineMatch' : '^# language: pl$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_pt.cson
+++ b/grammars/gherkin_pt.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.pt'
 'name': 'Gherkin-pt'
-'firstLineMatch' : '^# language: pt$'
+'firstLineMatch' : '^# language: pt$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_ro.cson
+++ b/grammars/gherkin_ro.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.ro'
 'name': 'Gherkin-ro'
-'firstLineMatch' : '^# language: ro$'
+'firstLineMatch' : '^# language: ro$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_ru.cson
+++ b/grammars/gherkin_ru.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.ru'
 'name': 'Gherkin-ru'
-'firstLineMatch' : '^# language: ru$'
+'firstLineMatch' : '^# language: ru$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_sk.cson
+++ b/grammars/gherkin_sk.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.sk'
 'name': 'Gherkin-sk'
-'firstLineMatch' : '^# language: sk$'
+'firstLineMatch' : '^# language: sk$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_sl.cson
+++ b/grammars/gherkin_sl.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.sl'
 'name': 'Gherkin-sl'
-'firstLineMatch' : '^# language: sl$'
+'firstLineMatch' : '^# language: sl$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_sr-Cyrl.cson
+++ b/grammars/gherkin_sr-Cyrl.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.sr-Cyrl'
 'name': 'Gherkin-sr-Cyrl'
-'firstLineMatch' : '^# language: sr-Cyrl$'
+'firstLineMatch' : '^# language: sr-Cyrl$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_sr-Latn.cson
+++ b/grammars/gherkin_sr-Latn.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.sr-Latn'
 'name': 'Gherkin-sr-Latn'
-'firstLineMatch' : '^# language: sr-Latn$'
+'firstLineMatch' : '^# language: sr-Latn$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_sv.cson
+++ b/grammars/gherkin_sv.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.sv'
 'name': 'Gherkin-sv'
-'firstLineMatch' : '^# language: sv$'
+'firstLineMatch' : '^# language: sv$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_ta.cson
+++ b/grammars/gherkin_ta.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.ta'
 'name': 'Gherkin-ta'
-'firstLineMatch' : '^# language: ta$'
+'firstLineMatch' : '^# language: ta$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_th.cson
+++ b/grammars/gherkin_th.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.th'
 'name': 'Gherkin-th'
-'firstLineMatch' : '^# language: th$'
+'firstLineMatch' : '^# language: th$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_tl.cson
+++ b/grammars/gherkin_tl.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.tl'
 'name': 'Gherkin-tl'
-'firstLineMatch' : '^# language: tl$'
+'firstLineMatch' : '^# language: tl$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_tlh.cson
+++ b/grammars/gherkin_tlh.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.tlh'
 'name': 'Gherkin-tlh'
-'firstLineMatch' : '^# language: tlh$'
+'firstLineMatch' : '^# language: tlh$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_tr.cson
+++ b/grammars/gherkin_tr.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.tr'
 'name': 'Gherkin-tr'
-'firstLineMatch' : '^# language: tr$'
+'firstLineMatch' : '^# language: tr$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_tt.cson
+++ b/grammars/gherkin_tt.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.tt'
 'name': 'Gherkin-tt'
-'firstLineMatch' : '^# language: tt$'
+'firstLineMatch' : '^# language: tt$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_uk.cson
+++ b/grammars/gherkin_uk.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.uk'
 'name': 'Gherkin-uk'
-'firstLineMatch' : '^# language: uk$'
+'firstLineMatch' : '^# language: uk$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_ur.cson
+++ b/grammars/gherkin_ur.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.ur'
 'name': 'Gherkin-ur'
-'firstLineMatch' : '^# language: ur$'
+'firstLineMatch' : '^# language: ur$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_uz.cson
+++ b/grammars/gherkin_uz.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.uz'
 'name': 'Gherkin-uz'
-'firstLineMatch' : '^# language: uz$'
+'firstLineMatch' : '^# language: uz$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_vi.cson
+++ b/grammars/gherkin_vi.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.vi'
 'name': 'Gherkin-vi'
-'firstLineMatch' : '^# language: vi$'
+'firstLineMatch' : '^# language: vi$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_zh-CN.cson
+++ b/grammars/gherkin_zh-CN.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.zh-CN'
 'name': 'Gherkin-zh-CN'
-'firstLineMatch' : '^# language: zh-CN$'
+'firstLineMatch' : '^# language: zh-CN$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/grammars/gherkin_zh-TW.cson
+++ b/grammars/gherkin_zh-TW.cson
@@ -1,6 +1,6 @@
 'scopeName': 'text.gherkin.feature.zh-TW'
 'name': 'Gherkin-zh-TW'
-'firstLineMatch' : '^# language: zh-TW$'
+'firstLineMatch' : '^# language: zh-TW$(\r)?\n'
 'fileTypes': [ 'feature' ]
 'patterns': [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "language-gherkin-i18n",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Gherkin language in Atom with support of Internationalization in more than 60 languages",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Updated firstLineMatch - regex to autodetect the language used both in CRLF and LF line ending files. Generated all affected files with the script and inserted fix into the Changelog.MD.
