### PR TITLE
Fix #7. Spaces in parameters names

### DIFF
--- a/generators/template/gherkin_grammar_template.cson
+++ b/generators/template/gherkin_grammar_template.cson
@@ -113,7 +113,7 @@ __LANG__
         'name': 'entity.name.function.decorator.gherkin'
     }
     {
-        'match': '(\\<\\w+\\>)'
+        'match': '(\\<(\\w+\\s*)+\\>)'
         'name': 'constant.character.escape.feature'
     }
     {


### PR DESCRIPTION
So, here it is.  
![default](https://cloud.githubusercontent.com/assets/1132840/12417104/adfdbf4c-beb6-11e5-8cf8-ccba8ce554f1.PNG)
