### PR TITLE
Fix increaseIndentPattern

### DIFF
--- a/generators/template/gherkin_settings_template.cson
+++ b/generators/template/gherkin_settings_template.cson
@@ -12,7 +12,5 @@ __THEN__
 __BUT__
 __AND__
     ]
-    'increaseIndentPattern': [
-__INCREASEINDENTPATTERNKEY__
-    ]
+    'increaseIndentPattern': __INCREASEINDENTPATTERNKEY__
     'commentStart': '# '


### PR DESCRIPTION
Fix #15.
increaseIndentPattern must be a string, not an array.

@mackoj Please, merge this and regenerate settings.
