### PR TITLE
Adds "Ukoliko" as croatian alternative for "given"

### DIFF
--- a/grammars/gherkin_hr.cson
+++ b/grammars/gherkin_hr.cson
@@ -85,7 +85,7 @@
         ]
     }
     {
-        'match': '\\s*(Zadan |Zadani |Zadano )'
+        'match': '\\s*(Zadan |Zadani |Zadano |Ukoliko )'
         'name': 'support.class.gherkin.given'
     }
     {


### PR DESCRIPTION
"Ukoliko" is word that is naturally used in Croatian for starting sentence. The word implies the givens of some reality that is described after the word. 