### PR TITLE
Completion for Ukoliko - Croatian Given alternative

### DIFF
--- a/settings/language-gherkin_hr.cson
+++ b/settings/language-gherkin_hr.cson
@@ -14,6 +14,7 @@
       'Zadan '
       'Zadani '
       'Zadano '
+      'Ukoliko '
       'Kada '
       'Kad '
       'Onda '


### PR DESCRIPTION
Ads completion for Ukoliko - croatian Given alternative. See https://github.com/mackoj/language-gherkin-i18n/pull/19